### PR TITLE
0.1.2 userinput

### DIFF
--- a/config/functions.cfg
+++ b/config/functions.cfg
@@ -5,6 +5,7 @@
 
 ; acia.s
   .global send_message_serial
+  .global copy_buffer_to_input_args
 
 ; lcd-4bit.s
   .global sys_lcd_init
@@ -14,3 +15,4 @@
 ; functions.s
   .global sys_led_on
   .global sys_led_off
+  .global sys_user_input

--- a/config/globals.cfg
+++ b/config/globals.cfg
@@ -2,7 +2,7 @@
 _GLOBALS_CFG_ = 1
 
 
-.define VERSION         "0.1.2b"
+.define VERSION         "0.1.2d"
 
 ; ACIA hardware pointers
 ACIA         = $4400

--- a/config/globals.cfg
+++ b/config/globals.cfg
@@ -2,7 +2,7 @@
 _GLOBALS_CFG_ = 1
 
 
-.define VERSION         "0.1.1d"
+.define VERSION         "0.1.2b"
 
 ; ACIA hardware pointers
 ACIA         = $4400
@@ -21,7 +21,7 @@ INPUT_COMMAND = $0303 ; 16 bytes $0303-$0312
 INPUT_ARGS    = $0313 ; 16 bytes $0313-$0322
 TEMP_VALUE    = $0323 ; 1 byte (used for ascii to byte conversion)
 ARG_VALUE     = $0324 ; 1 byte (value to be written to memory)
-MODE          = $0325 ; 1 byte (current state for irq decision)
+MODE          = $0325 ; 1 byte (mode of input for interrupt handler)
 VIA_PORTB_LO  = $0326 ; 1 byte
 VIA_PORTB_HI  = $0327 ; 1 byte
 VIA_PORTA_LO  = $0338 ; 
@@ -33,8 +33,18 @@ VIA_DDRA_HI   = $033d ; 1 byte
 LCDPOS        = $033e ; 1 byte (position on lcd, assuming 16x2)
 
 ; constants
-MODE_NONE           = $00
-MODE_XMODEM_RECEIVE = $01
+NULL    = $00
+EQUAL   = $00
+LT      = $ff
+GT      = $01
+
+; the global MODE affects interrupt driven serial input. the values are below
+MODE_NONE           = $00   ; normal mode
+MODE_XMODEM_RECEIVE = $01   ; fall through; xmodem does its own serial input
+MODE_USERINPUT      = $02   ; change behavior of enter key, instead of execute it signals end of input.
+MODE_USERINPUT_DONE = $03   ; flag so user input function can detect when input is complete, it must reset MODE
+
+INPUT_LENGTH = $0f          ; length of INPUT_ARGS 
 
 RUN_ADDR      = $3000
 

--- a/config/globals.cfg
+++ b/config/globals.cfg
@@ -2,7 +2,7 @@
 _GLOBALS_CFG_ = 1
 
 
-.define VERSION         "0.1.2d"
+.define VERSION         "0.1.2e"
 
 ; ACIA hardware pointers
 ACIA         = $4400
@@ -18,7 +18,7 @@ ACIA_RD_PTR   = $0300 ; 1 byte
 ACIA_WR_PTR   = $0301 ; 1 byte
 LED_STATUS    = $0302 ; 1 byte (really just bit 7)
 INPUT_COMMAND = $0303 ; 16 bytes $0303-$0312
-INPUT_ARGS    = $0313 ; 16 bytes $0313-$0322
+;             = $0313 ; 16 bytes $0313-$0322 (vacated since INPUT_ARGS moved)
 TEMP_VALUE    = $0323 ; 1 byte (used for ascii to byte conversion)
 ARG_VALUE     = $0324 ; 1 byte (value to be written to memory)
 MODE          = $0325 ; 1 byte (mode of input for interrupt handler)
@@ -31,6 +31,8 @@ VIA_DDRB_HI   = $033b ; 1 byte
 VIA_DDRA_LO   = $033c ; 1 byte
 VIA_DDRA_HI   = $033d ; 1 byte
 LCDPOS        = $033e ; 1 byte (position on lcd, assuming 16x2)
+;             = $033f ; through $03ff (padding ahead of INPUT_ARGS)
+INPUT_ARGS    = $0400 ; needs to aligned because indirect addressing only operates on lower half 
 
 ; constants
 NULL    = $00
@@ -44,7 +46,7 @@ MODE_XMODEM_RECEIVE = $01   ; fall through; xmodem does its own serial input
 MODE_USERINPUT      = $02   ; change behavior of enter key, instead of execute it signals end of input.
 MODE_USERINPUT_DONE = $03   ; flag so user input function can detect when input is complete, it must reset MODE
 
-INPUT_LENGTH = $0f          ; length of INPUT_ARGS 
+INPUT_ARGS_LENGTH = $0f          ; length of INPUT_ARGS 
 
 RUN_ADDR      = $3000
 

--- a/config/macros.cfg
+++ b/config/macros.cfg
@@ -1,0 +1,24 @@
+.ifndef _MACROS_CFG_
+_MACROS_CFG_ = 1
+
+
+.macro sys_start_userprogram
+  .word $3000               ; put origin at the top of the output binary file
+  .org $3000
+.endmacro
+
+.macro sys_end_userprogram
+  JMP prompt_loop           ; return to monitor loop
+.endmacro
+
+
+.macro sys_serial_print source
+  LDA #<source
+  STA ZP_MESSAGE
+  LDA #>source
+  STA ZP_MESSAGE+1
+  JSR send_message_serial
+.endmacro
+
+
+.endif

--- a/config/macros.cfg
+++ b/config/macros.cfg
@@ -3,21 +3,25 @@ _MACROS_CFG_ = 1
 
 
 .macro sys_start_userprogram
+  ; user program boilerplate (start of program)
   .word $3000               ; put origin at the top of the output binary file
-  .org $3000
+  .org $3000                ;
 .endmacro
 
 .macro sys_end_userprogram
+  ; user program boilerplate (end of program)
   JMP prompt_loop           ; return to monitor loop
 .endmacro
 
 
 .macro sys_serial_print source
+  ; print message to serial port
+  ; set ZP_MESSAGE to message source 
   LDA #<source
   STA ZP_MESSAGE
   LDA #>source
   STA ZP_MESSAGE+1
-  JSR send_message_serial
+  JSR send_message_serial   ; invoke serial print function
 .endmacro
 
 

--- a/src/acia.s
+++ b/src/acia.s
@@ -4,6 +4,7 @@
 
   .include "commands.s"
   .include "zeropage.cfg"
+  .include "globals.cfg"
 
 init_acia:
   PHA
@@ -94,22 +95,28 @@ acia_buffer_diff:       ; subtract buffer pointers. if there's a difference then
 
 
 copy_buffer_to_input_args:
-  PHA
+  ; copy acia buffer to input_args
+  ; assumptions
+  ; - both are 256 bytes
+  ; - acia buffer still holds input string
+  ; - we can clobber accumulator
   PHY
-  LDA #0                    ; initialize y to 0
-  TAY                       ;
-  JSR acia_buffer_diff      ; is buffer empty?
-  BEQ copy_buffer_to_input_args_done
-copy_buffer_to_input_args_loop:
+
+  JSR acia_buffer_diff      ; is buffer empty? if so just exit
+  BEQ cbtia_done
+
+  LDY #0                    ; initialize y to 0
+cbtia_loop:
   JSR read_acia_buffer      ; read char from buffer
   STA INPUT_ARGS,y
   INY
   JSR acia_buffer_diff      ; is buffer empty?
-  BNE copy_buffer_to_input_args_loop
+  BNE cbtia_loop
+cbtia_done:
+  LDA #NULL                 ; finish with NULL
+  STA INPUT_ARGS,y
 
-copy_buffer_to_input_args_done:
   PLY
-  PLA
   RTS
 
 

--- a/src/acia.s
+++ b/src/acia.s
@@ -155,6 +155,27 @@ acia_buffer_diff:       ; subtract buffer pointers. if there's a difference then
   SBC ACIA_RD_PTR
   RTS
 
+
+copy_buffer_to_input_args:
+  PHA
+  PHY
+  LDA #0                    ; initialize y to 0
+  TAY                       ;
+  JSR acia_buffer_diff      ; is buffer empty?
+  BEQ copy_buffer_to_input_args_done
+copy_buffer_to_input_args_loop:
+  JSR read_acia_buffer      ; read char from buffer
+  STA INPUT_ARGS,y
+  INY
+  JSR acia_buffer_diff      ; is buffer empty?
+  BNE copy_buffer_to_input_args_loop
+
+copy_buffer_to_input_args_done:
+  PLY
+  PLA
+  RTS
+
+
 perform_reset:
 ;   JMP reset
 ; perform_break:
@@ -229,6 +250,8 @@ key_enter_exit:           ; ready to exit
   PLX
   PLA
   JMP irq_reset_end_prompt
+
+
 
 ;
 ; take user input, truncates it at the first space

--- a/src/acia.s
+++ b/src/acia.s
@@ -54,69 +54,6 @@ send_message_serial_done:
   PLA
   RTS
 
-set_message_empty:
-  PHA
-  LDA #<message_empty
-  STA $08
-  LDA #>message_empty
-  STA $09
-  PLA
-  RTS
-
-set_message_startup:
-  PHA
-  LDA #<message_startup
-  STA $08
-  LDA #>message_startup
-  STA $09
-  PLA
-  RTS
-
-set_message_buffer:
-  PHA
-  LDA #<message_buffer
-  STA $08
-  LDA #>message_buffer
-  STA $09
-  PLA
-  RTS
-
-set_message_crlf:
-  PHA
-  LDA #<message_crlf
-  STA $08
-  LDA #>message_crlf
-  STA $09
-  PLA
-  RTS
-
-set_message_bufferfull:
-  PHA
-  LDA #<message_bufferfull
-  STA $08
-  LDA #>message_bufferfull
-  STA $09
-  PLA
-  RTS
-
-set_message_prompt:
-  PHA
-  LDA #<message_prompt
-  STA $08
-  LDA #>message_prompt
-  STA $09
-  PLA
-  RTS
-
-set_message_help:
-  PHA
-  LDA #<message_help
-  STA $08
-  LDA #>message_help
-  STA $09
-  PLA
-  RTS
-
 
 ;
 delay_6551:
@@ -180,11 +117,7 @@ perform_reset:
 ;   JMP reset
 ; perform_break:
   PHA
-  LDA #<message_break
-  STA $08
-  LDA #>message_break
-  STA $09
-  JSR send_message_serial
+  sys_serial_print message_break
   PLA
   JMP prompt_loop
 
@@ -278,8 +211,7 @@ copy_args_loop:
   STA INPUT_COMMAND,Y      ; put null where the space was
   INY                   ; forward to first char of arguments
 
-  JSR set_message_crlf
-  JSR send_message_serial
+  sys_serial_print message_crlf 
 
   LDX #0                ; position in args
 copy_to_args_loop:
@@ -320,8 +252,7 @@ print_buffer:
   ;
   JSR acia_buffer_diff
   BEQ print_buffer_empty
-  JSR set_message_buffer      ; set message to output
-  JSR send_message_serial            ; send message
+  sys_serial_print message_buffer    ;
 read_acia_buffer_loop:
   JSR read_acia_buffer        ; read char from buffer
   STA ACIA_DATA               ; output to serial console
@@ -332,8 +263,7 @@ read_acia_buffer_loop:
   JMP read_acia_buffer_loop
 read_acia_buffer_done:
   ;
-  JSR set_message_crlf        ; set message to CRLF
-  JSR send_message_serial
+  sys_serial_print message_crlf
 
 print_buffer_end:
   PLX
@@ -341,6 +271,5 @@ print_buffer_end:
   RTS
 
 print_buffer_empty:
-  JSR set_message_empty
-  JSR send_message_serial
+  sys_serial_print message_empty
   JMP print_buffer_end

--- a/src/commands.s
+++ b/src/commands.s
@@ -23,6 +23,7 @@ MODEM_RECEIVE_SUCCESS   = $01
 MODEM_RECEIVE_CANCELLED = $02
 
   .include "zeropage.cfg"
+  .include "macros.cfg"
   .include "xmodem.s"
   .include "sn76489.s"
 
@@ -208,19 +209,11 @@ parse_command_dump_continue:
 parse_command_load_continue:
 
   ; default - unknown
-  LDA #<message_unknown
-  STA ZP_MESSAGE
-  LDA #>message_unknown
-  STA ZP_MESSAGE+1
-  JSR send_message_serial
+  sys_serial_print message_unknown
   JMP option_done
 
 parse_command_help:
-  LDA #<message_help
-  STA ZP_MESSAGE
-  LDA #>message_help
-  STA ZP_MESSAGE+1
-  JSR send_message_serial
+  sys_serial_print message_help
   JMP option_done
 
 parse_command_beep:
@@ -232,11 +225,7 @@ parse_command_crash:
   JMP option_done
 
 parse_command_version:
-  LDA #<message_version
-  STA ZP_MESSAGE
-  LDA #>message_version
-  STA ZP_MESSAGE+1
-  JSR send_message_serial
+  sys_serial_print message_version
   JMP option_done
 
 
@@ -258,22 +247,15 @@ parse_command_led:      ; toggle via 2, port b, pin 7
   PLA                   ; restore ddr and send
   STA (ZP_VIA_DDRA,x)
 
-  LDA #<message_led     ; send toggle message
-  STA ZP_MESSAGE
-  LDA #>message_led
-  STA ZP_MESSAGE+1
-  JSR send_message_serial
+  ; send toggle message
+  sys_serial_print message_led
   ;
   JMP option_done
 
 
 parse_command_status:
   ; assuming led pin is in output mode
-  LDA #<message_status
-  STA ZP_MESSAGE
-  LDA #>message_status
-  STA ZP_MESSAGE+1
-  JSR send_message_serial
+  sys_serial_print message_status
   BIT LED_STATUS
   BMI status_led_on
 status_led_off:
@@ -309,11 +291,8 @@ parse_command_dump:
 
 parse_command_dump_run:
   ;
-  LDA #<message_read        ; print output header
-  STA ZP_MESSAGE
-  LDA #>message_read
-  STA ZP_MESSAGE+1
-  JSR send_message_serial
+  ; print output header
+  sys_serial_print message_read
   ;
   LDX #0
 dump_address_loop:
@@ -364,8 +343,7 @@ print_memory_line_loop:
   CPY #$10                  ; we are done when we hit $10
   BNE print_memory_line_loop
 
-  JSR set_message_crlf      ; go to next line
-  JSR send_message_serial
+  sys_serial_print message_crlf
   PLX
   PLY
   PLA
@@ -373,8 +351,7 @@ print_memory_line_loop:
 
 
 parse_command_load:
-  JSR set_message_crlf      ; go to next line
-  JSR send_message_serial
+  sys_serial_print message_crlf
   LDA #MODE_XMODEM_RECEIVE
   STA MODE
   JSR XModem
@@ -437,11 +414,8 @@ parse_command_read:
   STZ ZP_POINTER
   STZ ZP_POINTER+1
 
-  LDA #<message_read    ; print output header
-  STA ZP_MESSAGE
-  LDA #>message_read
-  STA ZP_MESSAGE+1
-  JSR send_message_serial
+  ; print output header
+  sys_serial_print message_read
 
   JSR parse_args_1_nnnn
 
@@ -453,11 +427,8 @@ parse_command_jmp:
   STZ ZP_POINTER
   STZ ZP_POINTER+1
 
-  LDA #<message_jmp    ; print output header
-  STA ZP_MESSAGE
-  LDA #>message_jmp
-  STA ZP_MESSAGE+1
-  JSR send_message_serial
+  ; print output header
+  sys_serial_print message_jmp
 
   JSR parse_args_1_nnnn
   LDX #$00
@@ -465,11 +436,8 @@ parse_command_jmp:
 
 
 parse_command_run:
-  LDA #<message_jmp    ; print output header
-  STA ZP_MESSAGE
-  LDA #>message_jmp
-  STA ZP_MESSAGE+1
-  JSR send_message_serial
+  ; print output header
+  sys_serial_print message_jmp
   ;
   LDA #<RUN_ADDR
   STA ZP_POINTER
@@ -480,11 +448,8 @@ parse_command_run:
 
 
 parse_command_jmp_return:
-  LDA #<message_jmp_return    ; print output header
-  STA ZP_MESSAGE
-  LDA #>message_jmp_return
-  STA ZP_MESSAGE+1
-  JSR send_message_serial
+  ; print output header
+  sys_serial_print message_jmp_return
   ;
   JSR print_memory_line
   JMP option_done

--- a/src/commands.s
+++ b/src/commands.s
@@ -16,10 +16,6 @@ COMMAND_STATUS:   .asciiz "status"
 COMMAND_WRITE:    .asciiz "write"
 COMMAND_VERSION:  .asciiz "version"
 
-NULL    = $00
-EQUAL   = $00
-LT      = $ff
-GT      = $01
 
 
 MODEM_RECEIVE_FAILED    = $00

--- a/src/commands.s
+++ b/src/commands.s
@@ -259,18 +259,11 @@ parse_command_status:
   BIT LED_STATUS
   BMI status_led_on
 status_led_off:
-  LDA #<message_led_off
-  STA ZP_MESSAGE
-  LDA #>message_led_off
-  STA ZP_MESSAGE+1
+  sys_serial_print message_led_off
   JMP status_led_done
 status_led_on:
-  LDA #<message_led_on
-  STA ZP_MESSAGE
-  LDA #>message_led_on
-  STA ZP_MESSAGE+1
+  sys_serial_print message_led_on
 status_led_done:
-  JSR send_message_serial
   JMP option_done
 
 

--- a/src/functions.s
+++ b/src/functions.s
@@ -41,3 +41,18 @@ sys_led_off:
   RTS
 
 
+sys_user_input:
+  PHA
+  LDA #MODE_USERINPUT               ; set mode to user input (affects interrupt driven input)
+  STA MODE
+  ; TODO following is needed here, not sure why yet. disable interrupts should nearly always remain cleared.
+  CLI
+sys_user_input_wait:
+  LDA MODE                          ; wait until userinput_done seen
+  CMP #MODE_USERINPUT_DONE          ;
+  BNE sys_user_input_wait           ;
+  JSR copy_buffer_to_input_args     ; once done inputting, copy contents from buffer to input args variable
+  LDA #MODE_NONE                    ; reset mode
+  STA MODE
+  PLA
+  RTS

--- a/src/monitor.s
+++ b/src/monitor.s
@@ -4,6 +4,7 @@
   .include "lcd-4bit.cfg"
   .include "via.cfg"
   .include "zeropage.cfg"
+  .include "globals.cfg"
 
   .code
 
@@ -119,10 +120,28 @@ key_escape_continue:
   JMP key_backspace
 key_backspace_continue:
 
-  CMP #$0d              ; enter
+  PHA
+  CMP #$0d                  ; enter
   BNE key_enter_continue
-  JMP key_enter
+  LDA MODE                  ; are we currently in userinput mode?
+  CMP #MODE_USERINPUT       ;
+  BEQ key_enter_userinput   ;
+  
+  ; LDA #'e'                  ; debug
+  ; JSR sys_lcd_printchar     ; debug
+  PLA                       ; restore character
+  JMP key_enter             ; then process enter normally
+
+key_enter_userinput:        ; enter key during userinput
+  ; LDA #'E'
+  ; JSR sys_lcd_printchar
+  LDA #MODE_USERINPUT_DONE  ; set userinput done flag
+  STA MODE
+  LDA #NULL                 ; add null to buffer
+  JSR write_acia_buffer
+
 key_enter_continue:
+  PLA
 
   CMP #$60              ; backtick
   BNE key_backtick_continue

--- a/src/monitor.s
+++ b/src/monitor.s
@@ -5,6 +5,7 @@
   .include "via.cfg"
   .include "zeropage.cfg"
   .include "globals.cfg"
+  .include "macros.cfg"
 
   .code
 
@@ -41,8 +42,7 @@ reset:
 
   jsr init_acia
 
-  jsr set_message_startup
-  jsr send_message_serial
+  sys_serial_print message_startup
 
   jsr init_display
 
@@ -81,10 +81,8 @@ init_via:
   RTS
 
 show_prompt:
-  JSR set_message_crlf
-  JSR send_message_serial
-  JSR set_message_prompt
-  JSR send_message_serial
+  sys_serial_print message_crlf
+  sys_serial_print message_prompt
   RTS
 
 loop:
@@ -167,8 +165,7 @@ perform_reset_continue:
   CMP #$f0
   BCC irq_end
 
-  JSR set_message_bufferfull
-  JSR send_message_serial
+  sys_serial_print message_bufferfull
   ; ; less than 0x0f (15) chars left, push rts down
   LDA #$01
   STA ACIA_COMMAND

--- a/src/monitor.s
+++ b/src/monitor.s
@@ -125,14 +125,10 @@ key_backspace_continue:
   CMP #MODE_USERINPUT       ;
   BEQ key_enter_userinput   ;
   
-  ; LDA #'e'                  ; debug
-  ; JSR sys_lcd_printchar     ; debug
   PLA                       ; restore character
   JMP key_enter             ; then process enter normally
 
 key_enter_userinput:        ; enter key during userinput
-  ; LDA #'E'
-  ; JSR sys_lcd_printchar
   LDA #MODE_USERINPUT_DONE  ; set userinput done flag
   STA MODE
   LDA #NULL                 ; add null to buffer
@@ -153,7 +149,6 @@ perform_reset_continue:
 
   ; all other keys, ...
   JSR write_acia_buffer
-  ;JSR print_char  ; display char on lcd 
 
   ; special keys are done.
   ; default action is to echo back
@@ -166,7 +161,7 @@ perform_reset_continue:
   BCC irq_end
 
   sys_serial_print message_bufferfull
-  ; ; less than 0x0f (15) chars left, push rts down
+  ; less than 0x0f (15) chars left, push rts down
   LDA #$01
   STA ACIA_COMMAND
   ; TODO what else should we do here? maybe soft reset or clear buffer.

--- a/user/Makefile
+++ b/user/Makefile
@@ -17,7 +17,7 @@ BIN_DIR=bin
 
 OBJS = hello.o
 
-all: hello blink
+all: hello blink input
 
 hello: $(OBJ_DIR)/monitor.o
 	$(CA65_BINARY) $(CA65_FLAGS) --include-dir $(CONFIG_DIR) -o $(BUILD_DIR)/hello.o src/hello.s
@@ -27,6 +27,9 @@ blink: $(OBJ_DIR)/monitor.o
 	$(CA65_BINARY) $(CA65_FLAGS) --include-dir $(CONFIG_DIR) -o $(BUILD_DIR)/blink.o src/blink.s
 	$(LD65_BINARY) $(LD65_FLAGS) -o $(BIN_DIR)/blink $(OBJ_DIR)/monitor.o $(BUILD_DIR)/blink.o
 
+input: $(OBJ_DIR)/monitor.o
+	$(CA65_BINARY) $(CA65_FLAGS) --include-dir $(CONFIG_DIR) -o $(BUILD_DIR)/input.o src/input.s
+	$(LD65_BINARY) $(LD65_FLAGS) -o $(BIN_DIR)/input $(OBJ_DIR)/monitor.o $(BUILD_DIR)/input.o
 
 clean:
 	/bin/rm -f $(BIN_DIR)/* $(BUILD_DIR)/* 

--- a/user/src/blink.s
+++ b/user/src/blink.s
@@ -1,5 +1,7 @@
 ; test "hello world" which blinks all pins on port a of via 2
   .include "functions.cfg"
+  .include "macros.cfg"
+
 
   .segment "USER"
 
@@ -7,8 +9,7 @@
   .import sys_led_on
   .import sys_led_off
 
-  .word $3000               ; put origin at the top of the output binary file
-  .org $3000
+  sys_start_userprogram
 
   JSR sys_led_on
 
@@ -18,7 +19,7 @@
 
   JSR sys_led_off
 
-  JMP prompt_loop
+  sys_end_userprogram
 
 
 delay_ay:

--- a/user/src/hello.s
+++ b/user/src/hello.s
@@ -2,6 +2,8 @@
 .segment "USER"
 
   .include "zeropage.cfg"
+  .include "macros.cfg"
+
 
   .import prompt_loop
   .import send_message_serial
@@ -10,16 +12,9 @@
   .import sys_lcd_clear
   .import sys_lcd_printchar
 
+  sys_start_userprogram
+  sys_serial_print message_test
 
-  .word $3000               ; put origin at the top of the output binary file
-  .org $3000
-
-  LDA #<message_test     ; send toggle message
-  STA ZP_MESSAGE
-  LDA #>message_test
-  STA ZP_MESSAGE+1
-  JSR send_message_serial
-  
   
   JSR sys_lcd_init
   JSR sys_lcd_clear
@@ -34,7 +29,7 @@
   LDA #$6f ; o
   JSR sys_lcd_printchar
 
-  JMP prompt_loop
+  sys_end_userprogram
 
 
 

--- a/user/src/input.s
+++ b/user/src/input.s
@@ -8,11 +8,11 @@
   .import prompt_loop
   .import send_message_serial
 
-  .import sys_lcd_init
-  .import sys_lcd_clear
-  .import sys_lcd_printchar
+  ; .import sys_lcd_init
+  ; .import sys_lcd_clear
+  ; .import sys_lcd_printchar
   .import sys_user_input
-  .import copy_buffer_to_input_args
+  ; .import copy_buffer_to_input_args
 
 
   sys_start_userprogram
@@ -22,11 +22,8 @@
   JSR sys_user_input              ; user input
 
   sys_serial_print message_test2
-
-  JSR copy_buffer_to_input_args   ; debug
-
   sys_serial_print INPUT_ARGS
- 
+
   sys_end_userprogram
 
 

--- a/user/src/input.s
+++ b/user/src/input.s
@@ -1,0 +1,34 @@
+; test "hello world" which blinks all pins on port a of via 2
+.segment "USER"
+
+  .include "zeropage.cfg"
+  .include "globals.cfg"
+  .include "macros.cfg"
+
+  .import prompt_loop
+  .import send_message_serial
+
+  .import sys_lcd_init
+  .import sys_lcd_clear
+  .import sys_lcd_printchar
+  .import sys_user_input
+  .import copy_buffer_to_input_args
+
+
+  sys_start_userprogram
+
+  sys_serial_print message_test
+
+  JSR sys_user_input              ; user input
+
+  sys_serial_print message_test2
+
+  JSR copy_buffer_to_input_args   ; debug
+
+  sys_serial_print INPUT_ARGS
+ 
+  sys_end_userprogram
+
+
+message_test:    .byte "Input text prompt: ", $00 ; CR LF NULL
+message_test2:   .byte $0d, $0a, "Text was: ", $00, $0d, $0a


### PR DESCRIPTION
add a user input mode variable. if we enter user input, set the flag and loop until the mode exits. this affects interrupt driven input. if the flag is set, pressing enter exits the input mode, instead of parsing the command.  the user input function needs to pull the contents out of the acia buffer.